### PR TITLE
Make PropTypes optional, allow React v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "rimraf": "^2.6.1"
   },
   "peerDependencies": {
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react": "^15.0.0 || ^16.0.0"
   },
   "scripts": {
     "clean": "rimraf lib",

--- a/src/OverflowDetector.jsx
+++ b/src/OverflowDetector.jsx
@@ -1,8 +1,14 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import ResizeDetector from './ResizeDetector';
 
+let PropTypes
+try {
+  PropTypes = require('prop-types');
+  if (PropTypes.default) PropTypes = PropTypes.default;
+} catch (err) {}
+
 export default class OverflowDetector extends Component {
-  static propTypes = {
+  static propTypes = PropTypes && {
     onOverflowChange: PropTypes.func,
     children: PropTypes.node,
     style: PropTypes.object,

--- a/src/ResizeDetector.jsx
+++ b/src/ResizeDetector.jsx
@@ -1,4 +1,10 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+
+let PropTypes
+try {
+  PropTypes = require('prop-types');
+  if (PropTypes.default) PropTypes = PropTypes.default;
+} catch (err) {}
 
 const OBJECT_STYLE = {
   display: 'block',
@@ -13,7 +19,7 @@ const OBJECT_STYLE = {
 };
 
 export default class ResizeDetector extends Component {
-  static propTypes = {
+  static propTypes = PropTypes && {
     onResize: PropTypes.func.isRequired,
   };
 


### PR DESCRIPTION
React 16 doesn't have PropTypes any more. Since it is up to the user if they want to use it, make it optional.

Also, the react-dom peer dependency was not necessary, although of course this package only works in the DOM :)