### PR TITLE
Add `onScrolled` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-overflow
 
-A React component that detects when it's overflowed by its content.
+A React component that detects when it's overflowed by its content. It can also tell you if you are at the edge of the scroll area.
 
 ## Installation
 
@@ -11,6 +11,8 @@ npm install --save react-overflow
 ```
 
 ## Usage
+
+Using the `onOverFlowChange` callback:
 
 ```jsx
 import { OverflowDetector } from 'react-overflow';
@@ -25,6 +27,30 @@ function handleOverflowChange(isOverflowed) {
 >
   <div style={{ width: '200px' }}>Overflowing</div>
 </OverflowDetector>
+```
+
+Using the `onScrolled` callback:
+
+```jsx
+import { OverflowDetector } from 'react-overflow';
+
+class TextWithArrows extends React.Component {
+  state = { atTop: true, atBottom: true, atLeft: true, atRight: true };
+  handleScrolled = pos => this.setState(pos);
+  render() {
+    const { text } = this.props;
+    const { atTop, atBottom, atLeft, atRight } = this.state;
+    return (
+      <ConstrainedTextDiv>
+        <OverflowDetector onScrolled={this.handleScrolled}>
+          {!atTop && <UpArrow />}
+          {text}
+          {!atBottom && <DownArrow />}
+        </OverflowDetector>
+      </ConstrainedTextDiv>
+    );
+  }
+}
 ```
 
 ## License

--- a/src/OverflowDetector.jsx
+++ b/src/OverflowDetector.jsx
@@ -17,8 +17,15 @@ export default class OverflowDetector extends Component {
     super(props);
     this.isOverflowed = false;
     this.domElement = null;
+    this.scrollState = {
+      atTop: true,
+      atBottom: true,
+      atLeft: true,
+      atRight: true,
+    };
     this.setDOMElement = this.setDOMElement.bind(this);
     this.checkOverflow = this.checkOverflow.bind(this);
+    this.handleScroll = this.handleScroll.bind(this);
   }
 
   componentDidMount() {
@@ -43,16 +50,48 @@ export default class OverflowDetector extends Component {
       if (this.props.onOverflowChange) {
         this.props.onOverflowChange(isOverflowed);
       }
+      if (!isOverflowed) {
+        this.handleScroll();
+      }
+    }
+  }
+
+  handleScroll() {
+    const {
+      clientHeight,
+      clientWidth,
+      scrollTop,
+      scrollLeft,
+      scrollHeight,
+      scrollWidth,
+    } = this.domElement;
+    const atTop = scrollTop === 0;
+    const atBottom = scrollTop + clientHeight === scrollHeight;
+    const atLeft = scrollLeft === 0;
+    const atRight = scrollLeft + clientWidth === scrollWidth;
+    const s = this.scrollState;
+    if (
+      s.atTop !== atTop ||
+      s.atBottom !== atBottom ||
+      s.atLeft !== atLeft ||
+      s.atRight !== atRight
+    ) {
+      const scrollState = { atTop, atBottom, atLeft, atRight };
+      this.scrollState = scrollState;
+      this.props.onScrolled(scrollState);
     }
   }
 
   render() {
-    const { style, className, children } = this.props;
+    const { style, className, children, onScrolled } = this.props;
+    const onScroll =
+      this.isOverflowed && onScrolled ? this.handleScroll : undefined;
     return (
       <div
         ref={this.setDOMElement}
         style={{ ...style, position: 'relative' }}
         className={className}
+        onScroll={onScroll}
       >
         {children}
         <ResizeDetector onResize={this.checkOverflow} />

--- a/src/ResizeDetector.jsx
+++ b/src/ResizeDetector.jsx
@@ -1,99 +1,58 @@
-import React, {Component, PropTypes} from 'react'
-import ResizeDetector from './ResizeDetector'
+import React, { Component, PropTypes } from 'react';
 
-export default class OverflowDetector extends Component {
-	static propTypes = {
-		onOverflowChange: PropTypes.func,
-		children: PropTypes.node,
-		style: PropTypes.object,
-		className: PropTypes.string,
-	}
+const OBJECT_STYLE = {
+  display: 'block',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  height: '100%',
+  width: '100%',
+  overflow: 'hidden',
+  pointerEvents: 'none',
+  zIndex: -1,
+};
 
-	static defaultProps = {
-		style: {},
-	}
+export default class ResizeDetector extends Component {
+  static propTypes = {
+    onResize: PropTypes.func.isRequired,
+  };
 
-	constructor(props) {
-		super(props)
-		this.isOverflowed = false
-		this.domElement = null
-		this.scrollState = {
-			atTop: true,
-			atBottom: true,
-			atLeft: true,
-			atRight: true,
-		}
-		this.setDOMElement = this.setDOMElement.bind(this)
-		this.checkOverflow = this.checkOverflow.bind(this)
-		this.handleScroll = this.handleScroll.bind(this)
-	}
+  constructor(props) {
+    super(props);
+    this.state = {
+      isMounted: false,
+    };
+    this.setDOMElement = this.setDOMElement.bind(this);
+    this.handleLoad = this.handleLoad.bind(this);
+  }
 
-	componentDidMount() {
-		this.checkOverflow()
-	}
+  componentDidMount() {
+    this.setState({
+      isMounted: true,
+    });
+  }
 
-	componentDidUpdate() {
-		this.checkOverflow()
-	}
+  componentWillUnmount() {
+    this.domElement.contentDocument.defaultView.removeEventListener('resize', this.props.onResize);
+  }
 
-	setDOMElement(domElement) {
-		this.domElement = domElement
-	}
+  setDOMElement(domElement) {
+    this.domElement = domElement;
+  }
 
-	checkOverflow() {
-		const isOverflowed =
-			this.domElement.scrollWidth > this.domElement.clientWidth ||
-			this.domElement.scrollHeight > this.domElement.clientHeight
+  handleLoad() {
+    this.domElement.contentDocument.defaultView.addEventListener('resize', this.props.onResize);
+  }
 
-		if (isOverflowed !== this.isOverflowed) {
-			this.isOverflowed = isOverflowed
-			if (this.props.onOverflowChange) {
-				this.props.onOverflowChange(isOverflowed)
-			}
-			if (!isOverflowed) {
-				this.handleScroll()
-			}
-		}
-	}
-
-	handleScroll() {
-		const {
-			clientHeight,
-			clientWidth,
-			scrollTop,
-			scrollLeft,
-			scrollHeight,
-			scrollWidth,
-		} = this.domElement
-		const atTop = scrollTop === 0
-		const atBottom = scrollTop + clientHeight === scrollHeight
-		const atLeft = scrollLeft === 0
-		const atRight = scrollLeft + clientWidth === scrollWidth
-		const s = this.scrollState
-		if (
-			s.atTop !== atTop ||
-			s.atBottom !== atBottom ||
-			s.atLeft !== atLeft ||
-			s.atRight !== atRight
-		) {
-			const scrollState = {atTop, atBottom, atLeft, atRight}
-			this.scrollState = scrollState
-			this.props.onScrolled(scrollState)
-		}
-	}
-
-	render() {
-		const {style, className, children, onScrolled} = this.props
-		return (
-			<div
-				ref={this.setDOMElement}
-				style={{...style, position: 'relative'}}
-				className={className}
-				onScroll={this.isOverflowed && onScrolled && this.handleScroll}
-			>
-				{children}
-				<ResizeDetector onResize={this.checkOverflow} />
-			</div>
-		)
-	}
+  render() {
+    return (
+      <object
+        style={OBJECT_STYLE}
+        type="text/html"
+        data={this.state.isMounted ? 'about:blank' : null}
+        ref={this.setDOMElement}
+        onLoad={this.handleLoad}
+      />
+    );
+  }
 }


### PR DESCRIPTION
This corrects and supersedes #2.

The use-case for this is to be able to add scroll indicators when the dom element is scrolled.

I wonder if perhaps the edge state should be provided in reverse, which would mean you don't need to initialize `state` nor negate the position. E.g. `notAtTop` etc? The example would then look like


```jsx
import { OverflowDetector } from 'react-overflow';

class TextWithArrows extends React.Component {
  state = {};
  handleScrolled = pos => this.setState(pos);
  render() {
    const { text } = this.props;
    const { notAtTop, notAtBottom, notAtLeft, notAtRight } = this.state;
    return (
      <ConstrainedTextDiv>
        <OverflowDetector onScrolled={this.handleScrolled}>
          {notAtTop && <UpArrow />}
          {text}
          {notAtBottom && <DownArrow />}
        </OverflowDetector>
      </ConstrainedTextDiv>
    );
  }
}
```