### PR TITLE
Add catch for if domElement.contentDocument is null

### DIFF
--- a/src/ResizeDetector.jsx
+++ b/src/ResizeDetector.jsx
@@ -35,10 +35,12 @@ export default class ResizeDetector extends Component {
   }
 
   componentWillUnmount() {
-    this.domElement.contentDocument.defaultView.removeEventListener(
-      'resize',
-      this.props.onResize
-    );
+    if (this.domElement.contentDocument) {
+      this.domElement.contentDocument.defaultView.removeEventListener(
+        'resize',
+        this.props.onResize
+      );
+    }
   }
 
   setDOMElement(domElement) {


### PR DESCRIPTION
Ran into this error using the overflow detector inside a React Portal. The Portal's `componentWillUnmount()` function removes it's children from the dom. When it hit's ResizeDetectors componentWillUnmount, `domElement.contentDocument` is null and throws `ResizeDetector.js:64 Uncaught TypeError: Cannot read property 'defaultView' of null`.